### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,20 @@ on:
     - cron: "0 7 * * 1"
 
 jobs:
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code formatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --format-prettier
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,25 @@
 name: ci
 
 on:
+
+lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
+
   push:
   pull_request:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2022, 2024 CERN.
+# Copyright (C) 2020, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-name: CI
+name: ci
 
 on:
   push:
@@ -32,12 +32,12 @@ jobs:
       - name: Check commit message compliance of the recently pushed commit
         if: github.event_name == 'push'
         run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
 
       - name: Check commit message compliance of the pull request
         if: github.event_name == 'pull_request'
         run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
   lint-shellcheck:
     runs-on: ubuntu-24.04
@@ -48,7 +48,7 @@ jobs:
       - name: Runs shell script static analysis
         run: |
           sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
+          ./run-tests.sh --lint-shellcheck
 
   validate:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,17 @@ lint-yamllint:
           pip install yamllint
           ./run-tests.sh --lint-yamllint
 
+format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --format-shfmt
+
   push:
   pull_request:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2022, 2023, 2024, 2026 CERN.
+# Copyright (C) 2020, 2022, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -7,26 +7,13 @@
 name: ci
 
 on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 7 * * 1"
 
-lint-yamllint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Lint YAML files
-        run: |
-          pip install yamllint
-          ./run-tests.sh --lint-yamllint
-
-format-shfmt:
+jobs:
+  format-shfmt:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -37,12 +24,6 @@ format-shfmt:
           sudo apt-get install shfmt
           ./run-tests.sh --format-shfmt
 
-  push:
-  pull_request:
-  schedule:
-    - cron: "0 7 * * 1"
-
-jobs:
   lint-commitlint:
     runs-on: ubuntu-24.04
     steps:
@@ -69,6 +50,20 @@ jobs:
         run: |
           ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --lint-markdownlint
+
   lint-shellcheck:
     runs-on: ubuntu-24.04
     steps:
@@ -79,6 +74,22 @@ jobs:
         run: |
           sudo apt-get install shellcheck
           ./run-tests.sh --lint-shellcheck
+
+  lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
 
   validate:
     runs-on: ubuntu-24.04

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,7 @@
-# Allow long lines (to be fixed when prettier is added)
-MD013: false
+# Allow long lines in code blocks and tables
+MD013:
+  code_blocks: false
+  tables: false
 # Allow prompt dollar sign in console examples without showing output
 MD014: false
 # Allow flexible list spacing

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+# Allow long lines (to be fixed when prettier is added)
+MD013: false
+# Allow prompt dollar sign in console examples without showing output
+MD014: false
+# Allow flexible list spacing
+MD032: false

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,6 +1,8 @@
 extends: default
 
 rules:
+  braces:
+    max-spaces-inside: 1
   comments:
     min-spaces-from-content: 1
   document-start: disable

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ and (4) which workflow steps were taken to run the analysis.
 ### 1. Input data
 
 This example uses ALICE Pb-Pb collision data input files. We can take a sample
-Pb-Pb ESD open data file that the ALICE collaboration released on the [CERN Open
-Data](http://opendata.cern.ch/) portal, for example the following sample taken
-at 3.5 TeV from run number 139038 in RunH 2010: (beware, the file is 360MB
-large)
+Pb-Pb ESD open data file that the ALICE collaboration released on the
+[CERN Open Data](http://opendata.cern.ch/) portal, for example the following
+sample taken at 3.5 TeV from run number 139038 in RunH 2010: (beware, the file
+is 360MB large)
 
 ```console
 $ mkdir -p __alice__data__2010__LHC10h_2__000139038
@@ -45,10 +45,10 @@ framework with the following source code files:
 
 - [env.sh](env.sh) - ALICE LEGO train system configuration
 - [generate.C](generate.C) - a macro to generate macros to run the ALICE LEGO
-train
+  train
 
 - [generator_customization.C](generator_customization.C) - generator
-customisations
+  customisations
 
 - [globalvariables.C](globalvariables.C) - global variables
 - [handlers.C](handlers.C) - data access handlers (ESD/AOD, collision/MC)
@@ -235,32 +235,36 @@ workflow steps and expected outputs:
 version: 0.3.0
 inputs:
   files:
-  - MLTrainDefinition.cfg
-  - data.txt
-  - env.sh
-  - generate.C
-  - generator_customization.C
-  - globalvariables.C
-  - handlers.C
-  - plot.C
-  - runTest.sh
-  - fix-env.sh
+    - MLTrainDefinition.cfg
+    - data.txt
+    - env.sh
+    - generate.C
+    - generator_customization.C
+    - globalvariables.C
+    - handlers.C
+    - plot.C
+    - runTest.sh
+    - fix-env.sh
 workflow:
   type: serial
   specification:
     steps:
-      - environment: 'docker.io/reanahub/reana-env-aliphysics:vAN-20180614-1'
+      - environment: "docker.io/reanahub/reana-env-aliphysics:vAN-20180614-1"
         commands:
-        - 'mkdir -p __alice__data__2010__LHC10h_2__000139038/'
-        - 'curl -fsOS --retry 9 http://opendata.cern.ch/eos/opendata/alice/2010/LHC10h/000139038/ESD/0003/AliESDs.root'
-        - 'mv AliESDs.root __alice__data__2010__LHC10h_2__000139038/'
-        - 'source fix-env.sh && source env.sh && aliroot -b -q generate.C | tee generation.log 2> generation.err'
-        - 'source fix-env.sh && source env.sh && export ALIEN_PROC_ID=12345678 && source ./lego_train.sh | tee stdout 2> stderr'
-        - 'source fix-env.sh && source env.sh && source ./lego_train_validation.sh | tee validation.log 2> validation.err'
-        - 'source fix-env.sh && source env.sh && root -b -q ./plot.C'
+          - "mkdir -p __alice__data__2010__LHC10h_2__000139038/"
+          - "curl -fsOS --retry 9
+            http://opendata.cern.ch/eos/opendata/alice/2010/LHC10h/000139038/ESD/0003/AliESDs.root"
+          - "mv AliESDs.root __alice__data__2010__LHC10h_2__000139038/"
+          - "source fix-env.sh && source env.sh && aliroot -b -q generate.C |
+            tee generation.log 2> generation.err"
+          - "source fix-env.sh && source env.sh && export ALIEN_PROC_ID=12345678
+            && source ./lego_train.sh | tee stdout 2> stderr"
+          - "source fix-env.sh && source env.sh && source
+            ./lego_train_validation.sh | tee validation.log 2> validation.err"
+          - "source fix-env.sh && source env.sh && root -b -q ./plot.C"
 outputs:
   files:
-  - plot.pdf
+    - plot.pdf
 ```
 
 We can now install the REANA command-line client, run the analysis and download

--- a/README.md
+++ b/README.md
@@ -7,24 +7,26 @@
 
 ## About
 
-This [REANA](http://www.reana.io/) reproducible analysis example performs ALICE LEGO
-train test run and validation. The procedure is used in ALICE collaboration particle
-physics analyses. Please see [arXiv:1502.06381](https://arxiv.org/abs/1502.06381) for
-more detailed description of the ALICE analysis train system.
+This [REANA](http://www.reana.io/) reproducible analysis example performs ALICE
+LEGO train test run and validation. The procedure is used in ALICE collaboration
+particle physics analyses. Please see
+[arXiv:1502.06381](https://arxiv.org/abs/1502.06381) for more detailed
+description of the ALICE analysis train system.
 
 ## Analysis structure
 
 Making a research data analysis reproducible means to provide "runnable recipes"
-addressing (1) where the input datasets are, (2) what software was used to analyse the
-data, (3) which computing environment was used to run the software, and (4) which
-workflow steps were taken to run the analysis.
+addressing (1) where the input datasets are, (2) what software was used to
+analyse the data, (3) which computing environment was used to run the software,
+and (4) which workflow steps were taken to run the analysis.
 
 ### 1. Input data
 
-This example uses ALICE Pb-Pb collision data input files. We can take a sample Pb-Pb ESD
-open data file that the ALICE collaboration released on the
-[CERN Open Data](http://opendata.cern.ch/) portal, for example the following sample taken
-at 3.5 TeV from run number 139038 in RunH 2010: (beware, the file is 360MB large)
+This example uses ALICE Pb-Pb collision data input files. We can take a sample
+Pb-Pb ESD open data file that the ALICE collaboration released on the [CERN Open
+Data](http://opendata.cern.ch/) portal, for example the following sample taken
+at 3.5 TeV from run number 139038 in RunH 2010: (beware, the file is 360MB
+large)
 
 ```console
 $ mkdir -p __alice__data__2010__LHC10h_2__000139038
@@ -33,7 +35,8 @@ $ curl -O http://opendata.cern.ch/eos/opendata/alice/2010/LHC10h/000139038/ESD/0
 $ cd ..
 ```
 
-Note that `data.txt` file should contain the path to the downloaded sample data file.
+Note that `data.txt` file should contain the path to the downloaded sample data
+file.
 
 ### 2. Analysis code
 
@@ -41,17 +44,21 @@ This example uses the [AliPhysics](https://github.com/alisw/AliPhysics) analysis
 framework with the following source code files:
 
 - [env.sh](env.sh) - ALICE LEGO train system configuration
-- [generate.C](generate.C) - a macro to generate macros to run the ALICE LEGO train
-- [generator_customization.C](generator_customization.C) - generator customisations
+- [generate.C](generate.C) - a macro to generate macros to run the ALICE LEGO
+train
+
+- [generator_customization.C](generator_customization.C) - generator
+customisations
+
 - [globalvariables.C](globalvariables.C) - global variables
 - [handlers.C](handlers.C) - data access handlers (ESD/AOD, collision/MC)
 - [runTest.sh](runTest.sh) - run LEGO train test and validation
 - [MLTrainDefinition.cfg](MLTrainDefinition.cfg) - train wagon definitions
 - [plot.C](plot.C) - plot sample histogram
 
-The user provides notably the [MLTrainDefinition.cfg](MLTrainDefinition.cfg) file which
-defines a set of train wagons that compose the analysis train run. In this example, the
-following wagons are defined:
+The user provides notably the [MLTrainDefinition.cfg](MLTrainDefinition.cfg)
+file which defines a set of train wagons that compose the analysis train run. In
+this example, the following wagons are defined:
 
 ```console
 $ grep Begin MLTrainDefinition.cfg
@@ -60,18 +67,18 @@ $ grep Begin MLTrainDefinition.cfg
 #Module.Begin        Run1NetPiBASE_CF_AP
 ```
 
-The first wagons are usually related to centralised data selection tasks, while the main
-user analysis is executed in the last `Run1NetPiBASE_CF_AP` wagon.
+The first wagons are usually related to centralised data selection tasks, while
+the main user analysis is executed in the last `Run1NetPiBASE_CF_AP` wagon.
 
-The `runTest.sh` script will take care of creating the train test run, running it, and
-validating its outputs.
+The `runTest.sh` script will take care of creating the train test run, running
+it, and validating its outputs.
 
 ### 3. Compute environment
 
-This example uses [AliPhysics](https://github.com/alisw/AliPhysics) analysis framework.
-It has been containerised as
-[reana-env-aliphysics](https://github.com/reanahub/reana-env-aliphysics) environment. You
-can fetch some wanted AliPhysics version from Docker Hub:
+This example uses [AliPhysics](https://github.com/alisw/AliPhysics) analysis
+framework. It has been containerised as
+[reana-env-aliphysics](https://github.com/reanahub/reana-env-aliphysics)
+environment. You can fetch some wanted AliPhysics version from Docker Hub:
 
 ```console
 $ docker pull docker.io/reanahub/reana-env-aliphysics:vAN-20180614-1
@@ -79,8 +86,9 @@ $ docker pull docker.io/reanahub/reana-env-aliphysics:vAN-20180614-1
 
 We shall use the `vAN-20180614-1` version for the present example.
 
-Note that if you would like to build a different AliPhysics version on your own, you can
-follow [reana-env-aliphysics](https://github.com/reanahub/reana-env-aliphysics)
+Note that if you would like to build a different AliPhysics version on your own,
+you can follow
+[reana-env-aliphysics](https://github.com/reanahub/reana-env-aliphysics)
 procedures and set `ALIPHYSICS_VERSION` environment variable appropriately:
 
 ```console
@@ -97,8 +105,8 @@ The researcher typically uses a single test run command:
 $ ./runTest.sh
 ```
 
-which performs all the tasks related to the analysis train generation, running and
-validation. Underneath, the following sequence of commands is called:
+which performs all the tasks related to the analysis train generation, running
+and validation. Underneath, the following sequence of commands is called:
 
 ```shell
 # generate the LEGO train run and validation files:
@@ -111,11 +119,12 @@ source ./lego_train.sh > stdout 2> stderr
 source ./lego_train_validation.sh > validation.log
 ```
 
-The produced log files indicate whether the train test run was successful and whether the
-output is validated.
+The produced log files indicate whether the train test run was successful and
+whether the output is validated.
 
-The computational workflow is therefore essentialy sequential in nature. We can use the
-REANA serial workflow engine and represent the analysis workflow as follows:
+The computational workflow is therefore essentialy sequential in nature. We can
+use the REANA serial workflow engine and represent the analysis workflow as
+follows:
 
 ```console
            START
@@ -170,13 +179,13 @@ REANA serial workflow engine and represent the analysis workflow as follows:
            STOP
 ```
 
-We shall see below how this sequence of commands is represented for the REANA serial
-workflow engine.
+We shall see below how this sequence of commands is represented for the REANA
+serial workflow engine.
 
 ### 5. Output results
 
-The output of the ALICE LEGO analysis train test run and validation is available in the
-`stdout` file. The success or failure is reported at the end:
+The output of the ALICE LEGO analysis train test run and validation is available
+in the `stdout` file. The success or failure is reported at the end:
 
 ```console
 $ tail -4 stdout
@@ -186,8 +195,8 @@ $ tail -4 stdout
 *******************************************************
 ```
 
-The test run will also create [ROOT](https://root.cern.ch/) output files that usually
-contain histograms.
+The test run will also create [ROOT](https://root.cern.ch/) output files that
+usually contain histograms.
 
 ```console
 $ ls -l AnalysisResults.root EventStat_temp.root
@@ -195,31 +204,32 @@ $ ls -l AnalysisResults.root EventStat_temp.root
 -rw-r--r-- 1 root root  31187 May 30 17:35 AnalysisResults.root
 ```
 
-The user typically uses the output files to produce final plots. For example, running
-`plot.C` output macro on the `AnalysisResults.root` output file will permit to visualise
-the centrality of accepted events:
+The user typically uses the output files to produce final plots. For example,
+running `plot.C` output macro on the `AnalysisResults.root` output file will
+permit to visualise the centrality of accepted events:
 
-![](https://raw.githubusercontent.com/reanahub/reana-demo-alice-lego-train-test-run/master/docs/plot.png)
+![image](https://raw.githubusercontent.com/reanahub/reana-demo-alice-lego-train-test-run/master/docs/plot.png)
 
-Low centralities mean that the the Pb particles hit each other a lot and many nucleons
-collide. High centralities mean that the Pb particles barely interacted and only very few
-nucelons did collide.
+Low centralities mean that the the Pb particles hit each other a lot and many
+nucleons collide. High centralities mean that the Pb particles barely interacted
+and only very few nucelons did collide.
 
 ## Running the example on REANA cloud
 
 There are two ways to execute this analysis example on REANA.
 
-If you would like to simply launch this analysis example on the REANA instance at CERN
-and inspect its results using the web interface, please click on the following badge:
+If you would like to simply launch this analysis example on the REANA instance
+at CERN and inspect its results using the web interface, please click on the
+following badge:
 
 [![image](https://www.reana.io/static/img/badges/launch-on-reana-at-cern.svg)](https://reana.cern.ch/launch?url=https%3A%2F%2Fgithub.com%2Freanahub%2Freana-demo-alice-lego-train-test-run&name=reana-demo-alice-lego-train-test-run)
 
-If you would like a step-by-step guide on how to use the REANA command-line client to
-launch this analysis example, please read on.
+If you would like a step-by-step guide on how to use the REANA command-line
+client to launch this analysis example, please read on.
 
-We start by creating a [reana.yaml](reana.yaml) file describing the above analysis
-structure with its inputs, code, runtime environment, computational workflow steps and
-expected outputs:
+We start by creating a [reana.yaml](reana.yaml) file describing the above
+analysis structure with its inputs, code, runtime environment, computational
+workflow steps and expected outputs:
 
 ```yaml
 version: 0.3.0
@@ -253,8 +263,8 @@ outputs:
   - plot.pdf
 ```
 
-We can now install the REANA command-line client, run the analysis and download the
-resulting plots:
+We can now install the REANA command-line client, run the analysis and download
+the resulting plots:
 
 ```console
 $ # create new virtual environment
@@ -283,5 +293,6 @@ $ reana-client download stdout
 $ reana-client download plot.pdf
 ```
 
-Please see the [REANA-Client](https://reana-client.readthedocs.io/) documentation for
-more detailed explanation of typical `reana-client` usage scenarios.
+Please see the [REANA-Client](https://reana-client.readthedocs.io/)
+documentation for more detailed explanation of typical `reana-client` usage
+scenarios.

--- a/reana.yaml
+++ b/reana.yaml
@@ -1,32 +1,36 @@
 version: 0.3.0
 inputs:
   files:
-   - MLTrainDefinition.cfg
-   - data.txt
-   - env.sh
-   - generate.C
-   - generator_customization.C
-   - globalvariables.C
-   - handlers.C
-   - plot.C
-   - runTest.sh
-   - fix-env.sh
+    - MLTrainDefinition.cfg
+    - data.txt
+    - env.sh
+    - generate.C
+    - generator_customization.C
+    - globalvariables.C
+    - handlers.C
+    - plot.C
+    - runTest.sh
+    - fix-env.sh
 workflow:
   type: serial
   specification:
     steps:
-      - environment: 'docker.io/reanahub/reana-env-aliphysics:vAN-20180614-1'
+      - environment: "docker.io/reanahub/reana-env-aliphysics:vAN-20180614-1"
         commands:
-        - 'mkdir -p __alice__data__2010__LHC10h_2__000139038/'
-        - 'curl -fsOS --retry 9 http://opendata.cern.ch/eos/opendata/alice/2010/LHC10h/000139038/ESD/0003/AliESDs.root'
-        - 'mv AliESDs.root __alice__data__2010__LHC10h_2__000139038/'
-        - 'source fix-env.sh && source env.sh && aliroot -b -q generate.C | tee generation.log 2> generation.err'
-        - 'source fix-env.sh && source env.sh && export ALIEN_PROC_ID=12345678 && source ./lego_train.sh | tee stdout 2> stderr'
-        - 'source fix-env.sh && source env.sh && source ./lego_train_validation.sh | tee validation.log 2> validation.err'
-        - 'source fix-env.sh && source env.sh && root -b -q ./plot.C'
+          - "mkdir -p __alice__data__2010__LHC10h_2__000139038/"
+          - "curl -fsOS --retry 9
+            http://opendata.cern.ch/eos/opendata/alice/2010/LHC10h/000139038/ESD/0003/AliESDs.root"
+          - "mv AliESDs.root __alice__data__2010__LHC10h_2__000139038/"
+          - "source fix-env.sh && source env.sh && aliroot -b -q generate.C |
+            tee generation.log 2> generation.err"
+          - "source fix-env.sh && source env.sh && export ALIEN_PROC_ID=12345678
+            && source ./lego_train.sh | tee stdout 2> stderr"
+          - "source fix-env.sh && source env.sh && source
+            ./lego_train_validation.sh | tee validation.log 2> validation.err"
+          - "source fix-env.sh && source env.sh && root -b -q ./plot.C"
 outputs:
   files:
-   - plot.pdf
+    - plot.pdf
 tests:
   files:
     - tests/log-messages.feature

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2024 CERN.
+# Copyright (C) 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,11 +9,15 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    npx commitlint --from="$from" --to="$to"
+    if command -v commitlint >/dev/null 2>&1; then
+        commitlint --from="$from" --to="$to"
+    else
+        npx commitlint --from="$from" --to="$to"
+    fi
     found=0
     while IFS= read -r line; do
         commit_hash=$(echo "$line" | cut -d ' ' -f 1)
@@ -43,23 +47,34 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
+lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
-check_all () {
-    check_commitlint
-    check_shellcheck
+all() {
+    lint_commitlint
+    lint_shellcheck
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all              Perform all checks [default]"
+    echo "  --help             Display this help message"
+    echo "  --lint-commitlint  Check linting of commit messages"
+    echo "  --lint-shellcheck  Check linting of shell scripts"
 }
 
 if [ $# -eq 0 ]; then
-    check_all
+    all
     exit 0
 fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--all) all ;;
+--help) help ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-shellcheck) lint_shellcheck ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_shfmt() {
+    shfmt -d .
+}
+
 lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
@@ -35,7 +39,7 @@ lint_commitlint() {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -56,6 +60,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_shfmt
     lint_commitlint
     lint_shellcheck
     lint_yamllint
@@ -65,6 +70,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all              Perform all checks [default]"
+    echo "  --format-shfmt     Check formatting of shell scripts"
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-shellcheck  Check linting of shell scripts"
@@ -80,6 +86,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_prettier() {
+    prettier -c .
+}
+
 format_shfmt() {
     shfmt -d .
 }
@@ -64,6 +68,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_prettier
     format_shfmt
     lint_commitlint
     lint_markdownlint
@@ -75,6 +80,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all                Perform all checks [default]"
+    echo "  --format-prettier    Check formatting of Markdown etc files"
     echo "  --format-shfmt       Check formatting of shell scripts"
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
@@ -92,6 +98,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-prettier) format_prettier ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-markdownlint) lint_markdownlint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -51,9 +51,14 @@ lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
+lint_yamllint() {
+    yamllint .
+}
+
 all() {
     lint_commitlint
     lint_shellcheck
+    lint_yamllint
 }
 
 help() {
@@ -63,6 +68,7 @@ help() {
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-shellcheck  Check linting of shell scripts"
+    echo "  --lint-yamllint    Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -76,5 +82,6 @@ case $arg in
 --help) help ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -51,6 +51,10 @@ lint_commitlint() {
     fi
 }
 
+lint_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
 lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
@@ -62,6 +66,7 @@ lint_yamllint() {
 all() {
     format_shfmt
     lint_commitlint
+    lint_markdownlint
     lint_shellcheck
     lint_yamllint
 }
@@ -69,12 +74,13 @@ all() {
 help() {
     echo "Usage: $0 [options]"
     echo "Options:"
-    echo "  --all              Perform all checks [default]"
-    echo "  --format-shfmt     Check formatting of shell scripts"
-    echo "  --help             Display this help message"
-    echo "  --lint-commitlint  Check linting of commit messages"
-    echo "  --lint-shellcheck  Check linting of shell scripts"
-    echo "  --lint-yamllint    Check linting of YAML files"
+    echo "  --all                Perform all checks [default]"
+    echo "  --format-shfmt       Check formatting of shell scripts"
+    echo "  --help               Display this help message"
+    echo "  --lint-commitlint    Check linting of commit messages"
+    echo "  --lint-markdownlint  Check linting of Markdown files"
+    echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --lint-yamllint      Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -88,6 +94,7 @@ case $arg in
 --help) help ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
+--lint-markdownlint) lint_markdownlint ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;

--- a/runTest.sh
+++ b/runTest.sh
@@ -1,37 +1,33 @@
 #!/bin/bash
 
-if [ ! -e "env.sh" ]
-then
-  echo "ERROR: env.sh not found."
-  exit 3
+if [ ! -e "env.sh" ]; then
+    echo "ERROR: env.sh not found."
+    exit 3
 fi
 # shellcheck disable=SC1091
 source env.sh
 
-if [ ! -e "generate.C" ]
-then
-  echo "ERROR: generate.C not found."
-  exit 3
+if [ ! -e "generate.C" ]; then
+    echo "ERROR: generate.C not found."
+    exit 3
 fi
-aliroot -b -q generate.C > generation.log
+aliroot -b -q generate.C >generation.log
 
-if [ ! -e "lego_train.sh" ]
-then
-  echo "ERROR: lego_train.sh not found."
-  exit 3
+if [ ! -e "lego_train.sh" ]; then
+    echo "ERROR: lego_train.sh not found."
+    exit 3
 fi
 #chmod u+x lego_train.sh
 
 # for MC generation testing
 export ALIEN_PROC_ID=12345678
 
-bash ./lego_train.sh > stdout 2> stderr
+bash ./lego_train.sh >stdout 2>stderr
 
-if [ ! -e "lego_train_validation.sh" ]
-then
-  echo "ERROR: lego_train_validation.sh not found."
-  exit 3
+if [ ! -e "lego_train_validation.sh" ]; then
+    echo "ERROR: lego_train_validation.sh not found."
+    exit 3
 fi
 #chmod u+x lego_train_validation.sh
 
-bash ./lego_train_validation.sh > validation.log
+bash ./lego_train_validation.sh >validation.log


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.